### PR TITLE
[BUGFIX] License code incorrectly parsed due to endianness

### DIFF
--- a/include/core/cartridge.h
+++ b/include/core/cartridge.h
@@ -13,7 +13,8 @@ typedef struct {
     u8   entry[4];        // Entry point (0x100 - 0x103)
     u8   logo[0x30];      // Nintendo logo (0x0104 - 0x0133)
     char title[16];       // Title in uppercase ASCII (0x0134 - 0x0143)
-    u16  new_lic;         // New license code (0x0144 - 0x0145)
+    u8   new_lic_hi;      // Upper 8 bits of the of new license code (0x0144)
+    u8   new_lic_lo;      // Lower 8 bits of the new license code (0x0145)
     u8   sgb_flag;        // SGB flag (0x0146)
     u8   type;            // Cartridge type (0x0147)
     u8   rom_size;        // ROM size (0x0148)
@@ -22,7 +23,8 @@ typedef struct {
     u8   old_lic_code;    // Old license code (0x14B) - if $33, use new_lic
     u8   version;         // Mask ROM version number (0x014C)
     u8   header_checksum; // 8-bit checksum for the header (0x014D)
-    u16  global_checksum; // 16-bit global checksum (0x014E - 0x014F)
+    u8   global_ck_hi;    // Upper 8 bits of 16-bit global checksum (0x014E)
+    u8   global_ck_lo;    // Lower 8 bits of 16-bit global checksum 0x014F)
 } RawRomHeader;
 
 // ---------------------------------------------

--- a/src/core/cartridge.c
+++ b/src/core/cartridge.c
@@ -126,10 +126,11 @@ void parse_header(const RawRomHeader *raw, CartHeader *out) {
     out->ram_size_code = raw->ram_size;
 
     // License code (use new if old is 0x33)
-    if (raw->old_lic_code == 0x33)
-        out->lic_code = raw->new_lic;
-    else
+    if (raw->old_lic_code == 0x33) {
+        out->lic_code = (raw->new_lic_hi << 8) | raw->new_lic_lo;
+    } else {
         out->lic_code = raw->old_lic_code;
+    }
 
     // Version
     out->version = raw->version;


### PR DESCRIPTION
## Description
This PR fixes the bug where **new license code** (at `0x0144` - 0x0145`) was being read incorrectly due to endianness.

### Closes #4

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Tests added/updated
- [ ] Documentation update

## Key Changes
- Change `u16 new_lic` to `u8 new_lic_hi` and `u8 new_lic_lo` to store the two-character ASCII “licensee code”.
- Use bitwise operations to set **license code** as the new license code from raw header (if the **old license code** == `0x33`)