### PR TITLE
[FEATURE] `CMake` build system now makes `baredmg` main binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,16 +8,26 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # Export compile commands for clangd
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Set default build type
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug)
+    message(STATUS "Build type not specified, defaulting to Debug")
+endif()
+
 # Compiler flags
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic")
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -O0")
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3")
+set(CMAKE_C_FLAGS_DEBUG "-g -O0")
+set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
 
 # Include directories
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
 # Build core library
 add_subdirectory(src/core)
+
+# Build main executable
+add_executable(baredmg src/main.c)
+target_link_libraries(baredmg gbcore)
 
 # NOTE: Build tests
 option(BUILD_TESTS "Build unit tests" ON)
@@ -27,6 +37,14 @@ if(BUILD_TESTS)
 endif()
 
 # Print build info
+message(STATUS "========================================")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "C Compiler: ${CMAKE_C_COMPILER}")
+message(STATUS "C Flags: ${CMAKE_C_FLAGS}")
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(STATUS "Debug flags: ${CMAKE_C_FLAGS_DEBUG}")
+elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+    message(STATUS "Release flags: ${CMAKE_C_FLAGS_RELEASE}")
+endif()
 message(STATUS "Build tests: ${BUILD_TESTS}")
+message(STATUS "========================================")

--- a/src/core/cartridge.c
+++ b/src/core/cartridge.c
@@ -64,7 +64,7 @@ int cart_load(Cartridge *cart, const char *path) {
         cart_unload(cart);
         return -1;
     }
-    printf("Cartridge header checksum: OK\n\n");
+    printf("\nCartridge header checksum: OK\n");
 
     // Allocate RAM if needed (based on ram_size_code)
     cart->ram_size = get_ram_size(cart->header.ram_size_code);

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,53 @@
+#include <gbemu.h>
+#include <core/cartridge.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Print the user Instructions
+static void print_usage(const char *program_name) {
+    printf("Usage: %s <path_to_rom>\n", program_name);
+    printf("\n");
+    printf("Options:\n");
+    printf("  <path_to_rom>    Path to Game Boy ROM file (.gb)\n");
+}
+
+int main(int argc, char *argv[]) {
+    // Check arguments
+    if (argc < 2) {
+        fprintf(stderr, "Error: No ROM file specified\n\n");
+        print_usage(argv[0]);
+        return -2;
+    }
+
+    const char *rom_path = argv[1];
+
+    // Print banner
+    printf("=================================\n");
+    printf("          BareDMG\n");
+    printf("    Game Boy Emulator (DMG-01)\n");
+    printf("=================================\n");
+    printf("\n");
+
+    // Initialize Game Boy
+    GameBoy gb;
+    gb_init(&gb);
+
+    // Load ROM && Print the parsed header
+    printf("Loading ROM: %s\n", rom_path);
+    gb_load_rom(&gb, rom_path);
+
+    // Check if the load was successful
+    if (!gb.running) {
+        fprintf(stderr, "Failed to load ROM\n");
+        return -3;
+    }
+
+    // ROM loaded Successfully
+    printf("ROM Loaded Successfully!\n");
+
+    // Clean up
+    cart_unload(&gb.cart);
+
+    puts("\nExiting...\n");
+    return 0;
+}


### PR DESCRIPTION
### Description
This PR updates the `CMake` build system, it now build the initial `baredmg` executable.

This creates a usable entry point for the project instead of the functionality being accessible only as a library.

### Related Issue
Closes #20

### Type of Change
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Tests added/updated
- [ ] Documentation update

### Key changes
- Updates `CMakeLists.txt` to build `baredmg` binary.
  - Accepts ROM path as argumet.
  - Loads ROM using existing library functions
  - Prints cartridge header information
  - Handles misisng arguments || invalid ROM errors
- Added `src/main.c` as the program's entry point.

### How to Test the Changes
1.Build the project
```zsh
mkdir build && cd build
cmake ..
make
```

2. Run `baredmg` with a valid ROM
```zsh
./baredmg <path/to/rom.gb?
```

### Test Output
<img width="1500" height="700" alt="image" src="https://github.com/user-attachments/assets/c6754c98-382f-4f1f-a36a-3c58e4f251f4" />


---
### Additional Notes for Maintainers (optional)
The error handling done by `src/main/c` doesn't take in account the error code that is returned by `cart_load()`

At some point we might need to make a central error handling system with error code defined for potential errors.