### PR TITLE
fix: replace range expressions with ISO C-compliant expressions

### DIFF
--- a/src/core/bus.c
+++ b/src/core/bus.c
@@ -214,6 +214,10 @@ void mmu_write(GameBoy *gb, u16 addr, u8 value) {
 
 // I/O Register handlers
 u8 io_read(GameBoy *gb, u16 addr) {
+    // Sound (NOTE: stubbed)
+    if (addr >= 0xFF10 && addr <= 0xFF26) {
+        return gb->io.sound[addr - 0xFF10];
+    }
     switch (addr) {
         // Joypad
         case 0xFF00:
@@ -238,10 +242,6 @@ u8 io_read(GameBoy *gb, u16 addr) {
         // Interrupt Flag (upper 3 bits always 1)
         case 0xFF0F:
             return gb->io.if_reg | 0xE0;
-
-        // Sound (NOTE: stubbed)
-        case 0xFF10 ... 0xFF26:
-            return gb->io.sound[addr - 0xFF10];
 
         // LCD
         case 0xFF40:
@@ -280,6 +280,12 @@ u8 io_read(GameBoy *gb, u16 addr) {
 }
 
 void io_write(GameBoy *gb, u16 addr, u8 value) {
+    // Sound (NOTE: stubbed)
+    if (addr >= 0xFF10 && addr <= 0xFF26) {
+        gb->io.sound[addr - 0xFF10] = value;
+        return;
+    }
+
     switch (addr) {
         // Joypad (bits 4-5 writable)
         case 0xFF00:
@@ -317,11 +323,6 @@ void io_write(GameBoy *gb, u16 addr, u8 value) {
         // Interrupt Flag (only lower 5 bits writable)
         case 0xFF0F:
             gb->io.if_reg = MASK_BITS(value, 0x1F);
-            break;
-
-        // Sound (NOTE: stubbed)
-        case 0xFF10 ... 0xFF26:
-            gb->io.sound[addr - 0xFF10] = value;
             break;
 
         // LCD


### PR DESCRIPTION
### Description
Replaces GNU switch case ranges with ISO C–compliant logic in `io_read()` and `io_write()` to eliminate `-Wpedantic` warnings.

### Related Issue
Closes #32 

### Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Tests added/updated
- [ ] Documentation update

### Key changes
- Replaced `case A ... B` with explicit bounds checks
- No functional behavior changes intended

### How to Test the Changes
This change is local to `src/core/bus.c`.

I could not complete a full build due to a missing header in my environment:

```
~/BareDMG/src/core/cpu/cpu.c:6:10: fatal error: utils.h: No such file or directory
compilation terminated.
```

This is unrelated to this PR and could be a good follow-up issue if this happens on other machines.

---