### PR TITLE
[FEATURE] Implement Blargg Test ROM validation

### DIFF
--- a/include/gbemu.h
+++ b/include/gbemu.h
@@ -68,7 +68,9 @@ typedef struct GameBoy {
     IORegisters io;
     u8          ie_register; // Interrupt Enable Register (0xFFFF)
 
-    u8        serial_data;
+    // Serial transfer state
+    u8          serial_data;
+    u16         serial_cycles;
 
     // System state
     u64         cycles;

--- a/include/gbemu.h
+++ b/include/gbemu.h
@@ -68,6 +68,8 @@ typedef struct GameBoy {
     IORegisters io;
     u8          ie_register; // Interrupt Enable Register (0xFFFF)
 
+    u8        serial_data;
+
     // System state
     u64         cycles;
     bool        running;

--- a/src/core/bus.c
+++ b/src/core/bus.c
@@ -299,10 +299,9 @@ void io_write(GameBoy *gb, u16 addr, u8 value) {
         case 0xFF02:
             gb->io.sc = value;
             if (CHECK_BIT(value, 7)) {
-                putchar(gb->io.sb);
-                fflush(stdout);
-                gb->io.sc     = CLEAR_BIT(gb->io.sc, 7);
-                gb->io.if_reg = SET_BIT(gb->io.if_reg, 3);
+                printf("[SERIAL] Starting transfer, SB=0x%02X ('%c')\n", gb->io.sb,
+                       gb->io.sb >= 0x20 && gb->io.sb < 0x7F ? gb->io.sb : '?');
+                gb->serial_cycles = 512;
             }
             break;
 

--- a/src/core/cpu/cpu.c
+++ b/src/core/cpu/cpu.c
@@ -86,6 +86,7 @@ u8 cpu_step(CPU *cpu) {
     if (cpu->halted) {
         // TODO: Check for interrupts here
         // If interrupt pending, unhalt
+        puts("This shit is halted");
         return 4;
     }
 

--- a/src/core/gbemu.c
+++ b/src/core/gbemu.c
@@ -63,6 +63,22 @@ void gb_step(GameBoy *gb) {
 
     u8 cycles = cpu_step(&gb->cpu);
     gb->cycles += cycles;
+
+    // Handle serial transfer
+    if (gb->serial_cycles > 0) {
+        if (gb->serial_cycles <= cycles) {
+            // Transfer complete
+            gb->serial_cycles = 0;
+            printf("[SERIAL] Outputting: '%c' (0x%02X)\n",
+                   gb->io.sb >= 0x20 && gb->io.sb < 0x7F ? gb->io.sb : '?', gb->io.sb);
+            putchar(gb->io.sb);
+            fflush(stdout);
+            gb->io.sc     = CLEAR_BIT(gb->io.sc, 7);
+            gb->io.if_reg = SET_BIT(gb->io.if_reg, 3);
+        } else {
+            gb->serial_cycles -= cycles;
+        }
+    }
 }
 
 // Run the emulator for the duration of one video frame

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,7 @@ static void print_usage(const char *program_name) {
     printf("\n");
     printf("Other options:\n");
     printf("  -d               Debug mode (verbose CPU state output)\n");
+    printf("  -t               Test mode: run ROM until completion (for test ROMs)\n");
     printf("  -h               Show this help message\n");
 }
 
@@ -56,6 +57,7 @@ int main(int argc, char *argv[]) {
     bool        mode_specified = false;
     bool        run_mode       = false;
     bool        debug_mode     = false;
+    bool        test_mode      = false;
     bool        info_mode      = false;
     int         step_count     = 0;
 
@@ -103,6 +105,15 @@ int main(int argc, char *argv[]) {
 
             else if (strcmp(argv[i], "-d") == 0) {
                 debug_mode = true;
+            }
+
+            else if (strcmp(argv[i], "-t") == 0) {
+                if (step_count > 0 || run_mode) {
+                    fprintf(stderr, "Error: -t cannot be used with -s or -r\n");
+                    return 1;
+                }
+                test_mode      = true;
+                mode_specified = true;
             }
 
             else {
@@ -210,6 +221,37 @@ int main(int argc, char *argv[]) {
 
         printf("\nEmulation finished.\n");
         print_cpu_state(&gb);
+    }
+
+    else if (test_mode) {
+        printf("Running test ROM...\n");
+        printf("(Serial output will appear below)\n");
+        printf("─────────────────────────────────\n\n");
+
+        u64 max_cycles = 100000000; // 100M cycles = ~24 seconds
+
+        while (gb.cycles < max_cycles && gb.running && !gb.cpu.halted) {
+            u8 cycles = cpu_step(&gb.cpu);
+            gb.cycles += cycles;
+
+            // Debug output if debug mode
+            if (debug_mode && (gb.cycles % 10000 == 0)) {
+                printf("[%llu cycles] PC=0x%04X\n", (unsigned long long)gb.cycles, gb.cpu.pc);
+            }
+        }
+
+        printf("\n─────────────────────────────────\n");
+
+        if (gb.cpu.halted) {
+            printf("Test completed (CPU halted)\n");
+            cart_unload(&gb.cart);
+            return 0;
+
+        } else if (gb.cycles >= max_cycles) {
+            printf("Test timeout (exceeded %llu cycles)\n", (unsigned long long)max_cycles);
+            cart_unload(&gb.cart);
+            return 1;
+        }
     }
 
     cart_unload(&gb.cart);

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,44 @@ static void print_usage(const char *program_name) {
     printf("  -h               Show this help message\n");
 }
 
+// NOTE: Test function to test the serial output
+// Working as of now
+static void test_serial_output(void) {
+    printf("\n=== Testing Serial Output ===\n");
+
+    GameBoy gb;
+    gb_init(&gb);
+
+    // Manually write to serial registers (simulating what ROM does)
+    io_write(&gb, 0xFF01, 'H');  // Write 'H' to SB
+    io_write(&gb, 0xFF02, 0x81); // Start transfer (bit 7 set)
+
+    printf("Serial cycles initialized: %d\n", gb.serial_cycles);
+    printf("Running cycles to complete transfer...\n");
+
+    // Run for 600 cycles to complete the 512-cycle transfer
+    for (int i = 0; i < 150; i++) { // 150 * 4 = 600 cycles
+        u8 cycles = 4;
+        gb.cycles += cycles;
+
+        // Handle serial transfer (copy from gb_step)
+        if (gb.serial_cycles > 0) {
+            if (gb.serial_cycles <= cycles) {
+                gb.serial_cycles = 0;
+                printf("[SERIAL] Outputting: '%c' (0x%02X)\n", gb.io.sb, gb.io.sb);
+                putchar(gb.io.sb);
+                fflush(stdout);
+                gb.io.sc     = CLEAR_BIT(gb.io.sc, 7);
+                gb.io.if_reg = SET_BIT(gb.io.if_reg, 3);
+            } else {
+                gb.serial_cycles -= cycles;
+            }
+        }
+    }
+
+    printf("\n=== Serial Test Complete ===\n\n");
+}
+
 // print the CPU state
 static void print_cpu_state(GameBoy *gb) {
     printf("\nFinal state:\n");
@@ -40,6 +78,7 @@ static void print_cpu_state(GameBoy *gb) {
 }
 
 int main(int argc, char *argv[]) {
+    /* test_serial_output(); */
 
     if (argc < 2) {
         fprintf(stderr, "Error: No ROM file specified\n\n");
@@ -228,11 +267,38 @@ int main(int argc, char *argv[]) {
         printf("(Serial output will appear below)\n");
         printf("─────────────────────────────────\n\n");
 
-        u64 max_cycles = 100000000; // 100M cycles = ~24 seconds
+        u64 max_cycles     = 100000000; // 100M cycles = ~24 seconds
+        u64 last_pc        = 0;
+        u64 pc_stuck_count = 0;
 
         while (gb.cycles < max_cycles && gb.running && !gb.cpu.halted) {
-            u8 cycles = cpu_step(&gb.cpu);
-            gb.cycles += cycles;
+            u16 pc_before = gb.cpu.pc;
+
+            gb_step(&gb);
+
+            // NOTE: Debug: Print first 100 instructions
+            // To be removed later on (This shit just isnt working right now)
+            if (gb.cycles < 500) {
+                printf("[%llu] PC=0x%04X opcode=0x%02X A=%02X F=%02X BC=%04X DE=%04X HL=%04X "
+                       "SP=%04X\n",
+                       (unsigned long long)gb.cycles, pc_before, mmu_read(&gb, pc_before),
+                       gb.cpu.regs.a, gb.cpu.regs.f, cpu_read_bc(&gb.cpu), cpu_read_de(&gb.cpu),
+                       cpu_read_hl(&gb.cpu), gb.cpu.sp);
+            }
+
+            // Detect infinite loops
+            if (pc_before == last_pc) {
+                pc_stuck_count++;
+                if (pc_stuck_count > 10000) {
+                    printf("\n[ERROR] CPU stuck in infinite loop at PC=0x%04X\n", pc_before);
+                    printf("Opcode at PC: 0x%02X\n", mmu_read(&gb, pc_before));
+                    break;
+                }
+
+            } else {
+                pc_stuck_count = 0;
+                last_pc        = pc_before;
+            }
 
             // Debug output if debug mode
             if (debug_mode && (gb.cycles % 10000 == 0)) {
@@ -249,6 +315,7 @@ int main(int argc, char *argv[]) {
 
         } else if (gb.cycles >= max_cycles) {
             printf("Test timeout (exceeded %llu cycles)\n", (unsigned long long)max_cycles);
+            printf("Final PC: 0x%04X\n", gb.cpu.pc);
             cart_unload(&gb.cart);
             return 1;
         }


### PR DESCRIPTION
### Description
This PR adds a test mode (`-t`) for running **Blargg/mooneye-style** test ROMs and cleans up how serial output is handled internally.

Serial output itself works (tested through a small function in `main.c`), but it’s still not printing to stdout when running in test mode.

I refactored the logic for **serial output** in `bus.c`,  and a bunch of debug logs to figure out the issue (might create a new issue for this).

I'd like to believe there's still a missing I/O register implementation or a timing issue causing the bug.

This does lay the foundation for running the test ROMs. The only problem is that the serial output is not working for test ROMs.

### Related Issue
Closes #25

### Type of Change
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [x] Breaking change (fix or feature that changes existing behavior)
- [ ] Tests added/updated
- [ ] Documentation update

### Key changes
- Add test mode `-t` to run the test roms
- Should print the serial output (**doesn't right now!**)
- Serial output does work tho, tested it using a test function defined in `main.c` commented as of now (un-comment to test the functionality)
- Refactor the serial output logic in `bus.c` (also added `serial_cycles`)
- Add a bunch of debug outputs to try to make it work

---
### Additional Notes for Maintainers (optional)
There's still a bug in the test mode due to which there's no serial output printed to stdout. I believe this will be fixed as we move forward - perhaps by implementing some other I/O Register, or some flaw in the logic which will be discovered as we move forward.