### PR TITLE
Refactor/36/cli args parsing

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -205,119 +205,22 @@ static void print_cpu_state(GameBoy *gb) {
 int main(int argc, char *argv[]) {
     /* test_serial_output(); */
 
-    if (argc < 2) {
-        fprintf(stderr, "Error: No ROM file specified\n\n");
-        print_usage(argv[0]);
-        return 1;
-    }
-
     // Print banner
     printf("=================================\n");
     printf("          BareDMG\n");
     printf("    Game Boy Emulator (DMG-01)\n");
     printf("=================================\n\n");
 
-    const char *rom_path       = NULL;
-    bool        mode_specified = false;
-    bool        run_mode       = false;
-    bool        debug_mode     = false;
-    bool        test_mode      = false;
-    bool        info_mode      = false;
-    int         step_count     = 0;
-
-    // Parse arguments
-    for (int i = 1; i < argc; i++) {
-
-        // Flag
-        if (argv[i][0] == '-') {
-
-            if (strcmp(argv[i], "-h") == 0) {
-                print_usage(argv[0]);
-                return 0;
-            }
-
-            else if (strcmp(argv[i], "-r") == 0) {
-                if (step_count > 0) {
-                    fprintf(stderr, "Error: -r and -s cannot be used together\n");
-                    return 1;
-                }
-                run_mode       = true;
-                mode_specified = true;
-            }
-
-            else if (strcmp(argv[i], "-s") == 0) {
-                if (run_mode) {
-                    fprintf(stderr, "Error: -s and -r cannot be used together\n");
-                    return 1;
-                }
-                if (i + 1 >= argc) {
-                    fprintf(stderr, "Error: -s requires a number\n");
-                    return 1;
-                }
-                step_count = atoi(argv[++i]);
-                if (step_count <= 0) {
-                    fprintf(stderr, "Error: Invalid step count\n");
-                    return 1;
-                }
-                mode_specified = true;
-            }
-
-            else if (strcmp(argv[i], "-i") == 0) {
-                info_mode      = true;
-                mode_specified = true;
-            }
-
-            else if (strcmp(argv[i], "-d") == 0) {
-                debug_mode = true;
-            }
-
-            else if (strcmp(argv[i], "-t") == 0) {
-                if (step_count > 0 || run_mode) {
-                    fprintf(stderr, "Error: -t cannot be used with -s or -r\n");
-                    return 1;
-                }
-                test_mode      = true;
-                mode_specified = true;
-            }
-
-            else {
-                fprintf(stderr, "Unknown option: %s\n", argv[i]);
-                print_usage(argv[0]);
-                return 1;
-            }
-        }
-
-        // Not a flag (ROM file)
-        else {
-            if (rom_path != NULL) {
-                fprintf(stderr, "Error: Multiple ROM files specified\n");
-                return 1;
-            }
-            rom_path = argv[i];
-        }
-    }
-
-    // Check if the ROM file was provided
-    if (!rom_path) {
-        fprintf(stderr, "Error: No ROM file specified\n\n");
-        print_usage(argv[0]);
+    // Parse CLI args
+    CliConfig config;
+    if (!parse_cli_args(argc, argv, &config)) {
         return 1;
-    }
-
-    // Default to info mode if no mode specified
-    if (!mode_specified) {
-        info_mode = true;
-        printf("No mode specified; defaulting to info mode (-i)\n\n");
-    }
-
-    if (info_mode && debug_mode) {
-        printf("Note: debug mode (-d) has no effect in info mode\n\n");
     }
 
     // Initialize Game Boy and load ROM
     GameBoy gb;
     gb_init(&gb);
-    gb_load_rom(&gb, rom_path);
+    gb_load_rom(&gb, config.rom_path);
 
     if (!gb.running) {
         fprintf(stderr, "Failed to load ROM\n");
@@ -327,20 +230,20 @@ int main(int argc, char *argv[]) {
     printf("ROM Loaded Successfully!\n");
 
     // Info mode: Exit after loading & printing cartridge info
-    if (info_mode) {
+    if (config.mode == MODE_INFO) {
         cart_unload(&gb.cart);
         return 0;
     }
 
     // Step mode
-    if (step_count > 0) {
-        printf("\nExecuting %d instructions...\n\n", step_count);
+    if (config.mode == MODE_STEP) {
+        printf("\nExecuting %d instructions...\n\n", config.step_count);
 
-        for (int i = 0; i < step_count; i++) {
+        for (int i = 0; i < config.step_count; i++) {
             u16 pc_before = gb.cpu.pc;
             u8  opcode    = mmu_read(&gb, pc_before);
 
-            if (debug_mode) {
+            if (config.debug_mode) {
                 printf("[%04d] PC=0x%04X Opcode=0x%02X "
                        "A=%02X B=%02X C=%02X D=%02X E=%02X H=%02X L=%02X "
                        "SP=%04X F=%02X\n",
@@ -368,7 +271,7 @@ int main(int argc, char *argv[]) {
     }
 
     // Run mode
-    else if (run_mode) {
+    else if (config.mode == MODE_RUN) {
         printf("Running emulator (press Ctrl+C to stop)...\n");
         printf("NOTE: No PPU/APU yet, this will just execute instructions.\n\n");
 
@@ -376,7 +279,7 @@ int main(int argc, char *argv[]) {
             gb_step(&gb);
 
             // Verbose output per interval if debug mode
-            if (debug_mode && (i % RUN_DEBUG_INTERVAL == 0)) {
+            if (config.debug_mode && (i % RUN_DEBUG_INTERVAL == 0)) {
                 printf("[RUN %06d] PC=0x%04X SP=0x%04X AF=%04X BC=%04X DE=%04X HL=%04X\n", i,
                        gb.cpu.pc, gb.cpu.sp, cpu_read_af(&gb.cpu), cpu_read_bc(&gb.cpu),
                        cpu_read_de(&gb.cpu), cpu_read_hl(&gb.cpu));
@@ -387,7 +290,7 @@ int main(int argc, char *argv[]) {
         print_cpu_state(&gb);
     }
 
-    else if (test_mode) {
+    else if (config.mode == MODE_TEST) {
         printf("Running test ROM...\n");
         printf("(Serial output will appear below)\n");
         printf("─────────────────────────────────\n\n");
@@ -426,7 +329,7 @@ int main(int argc, char *argv[]) {
             }
 
             // Debug output if debug mode
-            if (debug_mode && (gb.cycles % 10000 == 0)) {
+            if (config.debug_mode && (gb.cycles % 10000 == 0)) {
                 printf("[%llu cycles] PC=0x%04X\n", (unsigned long long)gb.cycles, gb.cpu.pc);
             }
         }

--- a/src/main.c
+++ b/src/main.c
@@ -34,6 +34,121 @@ static void print_usage(const char *program_name) {
     printf("  -h               Show this help message\n");
 }
 
+// Helper function to parse command line arguments into CliConfig
+static bool parse_cli_args(int argc, char *argv[], CliConfig *config) {
+    // Initialize defaults
+    config->rom_path   = NULL;
+    config->mode       = MODE_INFO; // Default mode
+    config->step_count = 0;
+    config->debug_mode = false;
+
+    if (argc < 2) {
+        fprintf(stderr, "Error: No ROM file specified\n\n");
+        print_usage(argv[0]);
+        return false;
+    }
+    bool mode_specified = false;
+
+    // Parse arguments
+    for (int i = 1; i < argc; i++) {
+
+        // Detect a flag
+        if (argv[i][0] == '-') {
+
+            // Help mode
+            if (strcmp(argv[i], "-h") == 0) {
+                print_usage(argv[0]);
+                exit(0);
+            }
+
+            // Run mode
+            else if (strcmp(argv[i], "-r") == 0) {
+                if (config->step_count > 0) {
+                    fprintf(stderr, "Error: -r and -s cannot be used together\n");
+                    return false;
+                }
+                config->mode   = MODE_RUN;
+                mode_specified = true;
+            }
+
+            // Step mode
+            else if (strcmp(argv[i], "-s") == 0) {
+                if (config->mode == MODE_RUN) {
+                    fprintf(stderr, "Error: -s and -r cannot be used together\n");
+                    return false;
+                }
+                if (i + 1 >= argc) {
+                    fprintf(stderr, "Error: -s requires a number\n");
+                    return false;
+                }
+                config->step_count = atoi(argv[++i]);
+                if (config->step_count <= 0) {
+                    fprintf(stderr, "Error: Invalid step count\n");
+                    return false;
+                }
+                config->mode   = MODE_STEP;
+                mode_specified = true;
+            }
+
+            // Info mode
+            else if (strcmp(argv[i], "-i") == 0) {
+                config->mode   = MODE_INFO;
+                mode_specified = true;
+            }
+
+            // Debug mode
+            else if (strcmp(argv[i], "-d") == 0) {
+                config->debug_mode = true;
+            }
+
+            // Test mode
+            else if (strcmp(argv[i], "-t") == 0) {
+                if (config->step_count > 0 || config->mode == MODE_RUN) {
+                    fprintf(stderr, "Error: -t cannot be used with -s or -r\n");
+                    return false;
+                }
+                config->mode   = MODE_TEST;
+                mode_specified = true;
+            }
+
+            else {
+                fprintf(stderr, "Unknown option: %s\n", argv[i]);
+                print_usage(argv[0]);
+                return false;
+            }
+        }
+
+        // Not a flag (ROM file)
+        else {
+            if (config->rom_path != NULL) {
+                fprintf(stderr, "Error: Multiple ROM files specified\n");
+                return false;
+            }
+            config->rom_path = argv[i];
+        }
+    }
+
+    // Check if the ROM file was provided
+    if (!config->rom_path) {
+        fprintf(stderr, "Error: No ROM file specified\n\n");
+        print_usage(argv[0]);
+        return false;
+    }
+
+    // Default to info mode if no mode specified
+    if (!mode_specified) {
+        config->mode = MODE_INFO;
+        printf("No mode specified; defaulting to info mode (-i)\n\n");
+    }
+
+    // Warn if info & debug mode both used
+    if (config->mode == MODE_INFO && config->debug_mode) {
+        printf("Note: debug mode (-d) has no effect in info mode\n\n");
+    }
+
+    return true;
+}
+
 // NOTE: Test function to test the serial output
 // Working as of now
 static void test_serial_output(void) {

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,16 @@
 
 #define RUN_DEBUG_INTERVAL 1000
 
+// Config structure for CLI args
+typedef enum { MODE_INFO, MODE_STEP, MODE_RUN, MODE_TEST } EmulatorMode;
+
+typedef struct {
+    const char  *rom_path;
+    EmulatorMode mode;
+    int          step_count;
+    bool         debug_mode;
+} CliConfig;
+
 // Print the usage information
 static void print_usage(const char *program_name) {
     printf("Usage: %s [options] <path_to_rom>\n", program_name);
@@ -62,7 +72,7 @@ static void test_serial_output(void) {
     printf("\n=== Serial Test Complete ===\n\n");
 }
 
-// print the CPU state
+// Print the CPU state
 static void print_cpu_state(GameBoy *gb) {
     printf("\nFinal state:\n");
     printf("  PC = 0x%04X\n", gb->cpu.pc);


### PR DESCRIPTION
### Description
As of this PR, the CLI args parsing logic is in `main()` in `main.c`. This makes it harder to maintain the codebase as it grows.

This PR extracts that cli args parsing logic from main into a dedicated static helper. Also introduced a struct to hold the cli config.

### Related Issue
#36

### Type of Change
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Tests added/updated
- [ ] Documentation update

### Key changes
- Introduced a struct `CliConfig`. This holds the cli config in it.
- Replaced the arg parsing logic in `main()` with  a static helper function `parse_cli_args`