### PR TITLE
[REFACTOR] Replace manual logging with logger helpers

### DIFF
--- a/include/core/utils.h
+++ b/include/core/utils.h
@@ -19,6 +19,29 @@ typedef int32_t  i32;
 typedef int64_t  i64;
 
 // ---------------------------------------------
+// ANSI Colors
+// ---------------------------------------------
+#define RED "\033[91m"          // Errors
+#define YELLOW "\033[93m"       // Warnings
+#define GREEN "\033[92m"        // Success
+#define CYAN "\033[96m"         // Information
+#define BLUE "\033[94m"         // Debug
+#define MAGENTA "\033[95m"      // Emulator-specific
+#define BOLD_WHITE "\033[1;97m" // Bold white
+#define RESET "\033[0m"
+
+// ---------------------------------------------
+// Logger functions
+// ---------------------------------------------
+void put_error(const char *format, ...);
+void put_warning(const char *format, ...);
+void put_success(const char *format, ...);
+void put_info(const char *format, ...);
+void put_debug(const char *format, ...);
+void put_emulator(const char *format, ...);
+void put_bold(const char *msg);
+
+// ---------------------------------------------
 // Bit Manipulation Macros (simple, inline)
 // ---------------------------------------------
 

--- a/src/core/bus.c
+++ b/src/core/bus.c
@@ -378,14 +378,14 @@ void io_write(GameBoy *gb, u16 addr, u8 value) {
 
 // Debug Helper: Dump Memory Region
 void mmu_dump_region(GameBoy *gb, u16 start, u16 end) {
-    printf("Memory Dump [0x%04x - 0x%04x]:\n", start, end);
+    printf("%sMemory Dump%s ", BOLD_WHITE, RESET);
+    printf("[0x%04X - 0x%04X]:\n", start, end);
 
     for (u16 addr = start; addr <= end; addr += 16) {
-        printf("0x%04x: ", addr);
+        printf("%s0x%04X:%s ", CYAN, addr, RESET);
 
-        // Print B in hex
-        for (int i = 0; i < 16 && (addr + 1) <= end; i++) {
-            printf("%02x ", mmu_read(gb, addr + 1));
+        for (int i = 0; i < 16 && (addr + i) <= end; i++) {
+            printf("%02X ", mmu_read(gb, addr + i));
         }
 
         printf("\n");

--- a/src/core/cartridge.c
+++ b/src/core/cartridge.c
@@ -19,7 +19,7 @@ int cart_load(Cartridge *cart, const char *path) {
     // Open the ROM file
     FILE *rom_f = fopen(path, "rb");
     if (!rom_f) {
-        fprintf(stderr, "Failed to open ROM: %s\n", path);
+        put_error("Failed to open ROM: %s\n", path);
         return 1;
     }
 
@@ -31,54 +31,64 @@ int cart_load(Cartridge *cart, const char *path) {
     // Actual ROM file size should be greater than 0x0150
     if (cart->rom_size < 0x0150) {
         fclose(rom_f);
-        fprintf(stderr, "ROM file too small\n");
+        put_error("ROM file too small!\n");
         return 2;
     }
 
-    // Allocate memory for ROM from heap
+    // Allocate memory for ROM on the heap
     cart->rom = malloc(cart->rom_size);
     if (!cart->rom) {
         fclose(rom_f);
-        fprintf(stderr, "Failed to allocate ROM memory\n");
+        put_error("Failed to allocate memory for ROM!\n");
         return 3;
     }
+    put_success("ROM Memory allocated successfully!\n");
 
     // Read the ROM data from file into ROM buffer
+    put_emulator("Reading ROM data into ROM buffer...\n");
     size_t read = fread(cart->rom, 1, cart->rom_size, rom_f);
     fclose(rom_f);
 
     if (read != cart->rom_size) {
-        fprintf(stderr, "Failed to read ROM\n");
+        put_error("Failed to read ROM\n");
         return 5;
     }
 
-    printf("ROM Loaded Successfully!\n");
+    put_success("ROM loaded successfully!\n\n");
 
     // Copy raw header (located at 0x100 - 0x14F)
     memcpy(&cart->raw_header, cart->rom + 0x0100, sizeof(RawRomHeader));
 
     // Parse the header into usable format
+    put_emulator("Parsing cartridge header...\n");
     parse_header(&cart->raw_header, &cart->header);
+    put_success("Cartridge header parsed successfully!\n\n");
 
     // Verify the header checksum
+    put_emulator("Verifying the header checksum...\n");
     if (!cart_verify_header_checksum(cart)) {
-        fprintf(stderr, "Error: Invalid cartridge header checksum\n");
+        put_error("Invalid cartridge header checksum!\n");
+        put_emulator("Unloading cartridge...\n");
         cart_unload(cart);
         return -1;
     }
-    printf("\nCartridge header checksum: OK\n");
+    put_success("Cartridge header checksum valid!\n\n");
 
     // Allocate RAM if needed (based on ram_size_code)
     cart->ram_size = get_ram_size(cart->header.ram_size_code);
+
     if (cart->ram_size > 0) {
+        put_emulator("Allocating cartridge RAM...\n");
+
         cart->ram = calloc(1, cart->ram_size);
         if (!cart->ram) {
-            fprintf(stderr, "Failed to allocate cartridge RAM\n");
+            put_error("Failed to allocate cartridge RAM!\n");
             free(cart->rom);
             cart->rom      = NULL;
             cart->rom_size = 0;
             return 4;
         }
+        put_success("Cartridge RAM allocated successfully!\n\n");
     }
     else {
         cart->ram = NULL;
@@ -148,9 +158,9 @@ void cart_print_header(const CartHeader *hdr) {
     bool        is_old_code = (hdr->lic_code <= 0xFF);
     const char *publisher   = get_publisher_name(hdr->lic_code, is_old_code);
 
-    printf("================================\n");
-    printf("    Cartridge Information\n");
-    printf("================================\n");
+    put_bold("================================\n");
+    put_bold("    Cartridge Information\n");
+    put_bold("================================\n");
 
     printf("Title:         %s\n", hdr->title);
     printf("Publisher:     %s (0x%04X)\n", publisher, hdr->lic_code);
@@ -168,7 +178,7 @@ void cart_print_header(const CartHeader *hdr) {
 
     printf("SGB Support:   %s\n", hdr->sgb_supported ? "Yes" : "No");
     printf("CGB Support:   %s\n", hdr->cgb_supported ? "Yes" : "No");
-    printf("================================\n");
+    put_bold("================================\n\n");
 }
 
 // Get RAM size in bytes from RAM size code
@@ -188,7 +198,7 @@ size_t get_ram_size(u8 ram_size_code) {
         case 0x05:
             return 64 * 1024; // 64 KB (8 banks of 8KB)
         default:
-            fprintf(stderr, "Unknown RAM size code: 0x%02X\n", ram_size_code);
+            put_error("Unknwon RAM size code: 0x%02x\n", ram_size_code);
             return 0;
     }
 }
@@ -216,7 +226,7 @@ size_t get_rom_size(u8 rom_size_code) {
         case 0x54:
             return 96 * 16 * 1024; // 1.5 MB
         default:
-            fprintf(stderr, "Unknown ROM size code: 0x%02X\n", rom_size_code);
+            put_error("Unknown ROM size code: 0x%02X\n", rom_size_code);
             return 0;
     }
 }

--- a/src/core/cpu/cpu.c
+++ b/src/core/cpu/cpu.c
@@ -14,6 +14,7 @@ void cpu_init(CPU *cpu, GameBoy *gb) {
 void cpu_reset(CPU *cpu) {
     // Game Boy boot sequence sets these initial values
     // https://gbdev.io/pandocs/Power_Up_Sequence.html
+    put_emulator("Resetting CPU...\n");
     cpu->regs.a = 0x01; // GB/SGB identifier
     cpu->regs.f = 0xB0; // Flags: Z = 1, N = 0, H = 1, C = 1
     cpu->regs.b = 0x00;
@@ -28,6 +29,7 @@ void cpu_reset(CPU *cpu) {
 
     cpu->ime    = false;
     cpu->halted = false;
+    put_success("CPU reset successfully\n\n");
 }
 
 // Register Pair Read Functions
@@ -86,7 +88,7 @@ u8 cpu_step(CPU *cpu) {
     if (cpu->halted) {
         // TODO: Check for interrupts here
         // If interrupt pending, unhalt
-        puts("This shit is halted");
+        put_warning("CPU halted!\n");
         return 4;
     }
 

--- a/src/core/cpu/cpu_tables.c
+++ b/src/core/cpu/cpu_tables.c
@@ -306,7 +306,7 @@ static const InstrFunc instr_table[256] = {
 u8 cpu_execute(CPU *cpu, u8 opcode) {
     // Check if instruction is implemented
     if (instr_table[opcode] == NULL) {
-        fprintf(stderr, "Illegal Operation Code: 0x%02x at PC = 0x%04x\n", opcode, cpu->pc - 1);
+        put_error("Illegal operation code: 0x%02x at PC = 0x%04x\n", opcode, cpu->pc - 1);
         return ILLEGAL;
     }
     return instr_table[opcode](cpu);

--- a/src/core/gbemu.c
+++ b/src/core/gbemu.c
@@ -10,6 +10,7 @@ void gb_init(GameBoy *gb) {
     cpu_init(&gb->cpu, gb);
 
     // Initialize I/O registers to power-up state
+    put_emulator("Initializing I/O registers to power-up state...\n");
     gb->io.joyp     = 0xCF;
 
     gb->io.sb       = 0x00;
@@ -36,27 +37,31 @@ void gb_init(GameBoy *gb) {
     gb->io.wx       = 0x00;
 
     gb->io.boot     = 0x00;
+    put_success("I/O registers initialized successfully!\n\n");
 }
 
 // Load a cartridge into GameBoy
+// TODO: Remove the call to cart_print_header
+// Create a proper gb_print_cart_info() to print header when info mode is set
 void gb_load_rom(GameBoy *gb, const char *path) {
     // Try to load the cartridge
     // TODO: Might print details about the error (using error codes)
+    put_emulator("Loading ROM...\n");
     if (cart_load(&gb->cart, path) != 0) {
-        /* fprintf(stderr, "Failed to load ROM\n"); */
+        put_error("Failed to load ROM!\n");
         gb->running = false;
         return;
     }
 
-    printf("\n");
+    put_emulator("Printing cartridge information below...\n\n");
     cart_print_header(&gb->cart.header);
-    printf("\n");
 
-    cpu_reset(&gb->cpu);
+    // FIX: CPU is already reset by gb_init()
+    /* cpu_reset(&gb->cpu); */
     gb->running = true;
 }
 
-// Exeucte a single CPU instruction step
+// Execute a single CPU instruction step
 void gb_step(GameBoy *gb) {
     if (!gb->running)
         return;
@@ -100,7 +105,7 @@ void gb_run_frame(GameBoy *gb) {
 
 // Dump PC/SP/register pairs/flags/cycle count (for debugging)
 void gb_print_state(GameBoy *gb) {
-    printf("\nFinal state:\n");
+    printf("\n%sFinal state:%s\n", BOLD_WHITE, RESET);
     printf("  PC = 0x%04X\n", gb->cpu.pc);
     printf("  SP = 0x%04X\n", gb->cpu.sp);
     printf("  AF = 0x%04X\n", cpu_read_af(&gb->cpu));
@@ -110,12 +115,15 @@ void gb_print_state(GameBoy *gb) {
     printf("  Flags: Z=%d N=%d H=%d C=%d\n", cpu_get_flag(&gb->cpu, FLAG_ZERO),
            cpu_get_flag(&gb->cpu, FLAG_SUBT), cpu_get_flag(&gb->cpu, FLAG_HF_CARRY),
            cpu_get_flag(&gb->cpu, FLAG_CARRY));
-    printf("  Total cycles: %llu\n", (unsigned long long)gb->cycles);
+    printf("  Total cycles: %llu\n\n", (unsigned long long)gb->cycles);
 }
 
 // Execute exactly `step_count` instructions (-s <num>)
 GbRunStatus gb_run_step(GameBoy *gb, int step_count, bool debug_mode) {
-    printf("\nExecuting %d instructions...\n\n", step_count);
+    if (debug_mode)
+        put_emulator("Executing %d instructions (in debug mode)...\n\n", step_count);
+    else
+        put_emulator("Executing %d instructions...\n", step_count);
 
     GbRunStatus status = GB_RUN_OK;
 
@@ -124,24 +132,24 @@ GbRunStatus gb_run_step(GameBoy *gb, int step_count, bool debug_mode) {
         u8  opcode    = mmu_read(gb, pc_before);
 
         if (debug_mode) {
-            printf("[%04d] PC=0x%04X Opcode=0x%02X "
-                   "A=%02X B=%02X C=%02X D=%02X E=%02X H=%02X L=%02X "
-                   "SP=%04X F=%02X\n",
-                   i, pc_before, opcode, gb->cpu.regs.a, gb->cpu.regs.b, gb->cpu.regs.c,
-                   gb->cpu.regs.d, gb->cpu.regs.e, gb->cpu.regs.h, gb->cpu.regs.l, gb->cpu.sp,
-                   gb->cpu.regs.f);
+            put_debug("[%04d] PC=0x%04X Opcode=0x%02X "
+                      "A=%02X B=%02X C=%02X D=%02X E=%02X H=%02X L=%02X "
+                      "SP=%04X F=%02X\n",
+                      i, pc_before, opcode, gb->cpu.regs.a, gb->cpu.regs.b, gb->cpu.regs.c,
+                      gb->cpu.regs.d, gb->cpu.regs.e, gb->cpu.regs.h, gb->cpu.regs.l, gb->cpu.sp,
+                      gb->cpu.regs.f);
         }
 
         gb_step(gb);
 
         if (gb->cpu.halted) {
-            printf("\nCPU halted at PC=0x%04X after %d instructions\n", pc_before, i + 1);
+            put_info("\nCPU halted at PC=0x%04X after %d instructions\n", pc_before, i + 1);
             status = GB_RUN_HALTED;
             break;
         }
 
         if (gb->cpu.pc == pc_before && opcode != 0x76) {
-            printf("\nInfinite loop detected at PC=0x%04X\n", pc_before);
+            put_error("\nInfinite loop detected at PC=0x%04X\n", pc_before);
             status = GB_RUN_STUCK;
             break;
         }
@@ -153,30 +161,45 @@ GbRunStatus gb_run_step(GameBoy *gb, int step_count, bool debug_mode) {
 
 // Execute until HALT or an internal iteration cap (-r)
 GbRunStatus gb_run_continuous(GameBoy *gb, bool debug_mode) {
-    printf("Running emulator (press Ctrl+C to stop)...\n");
-    printf("NOTE: No PPU/APU yet, this will just execute instructions.\n\n");
+    if (debug_mode) {
+        put_emulator("Running emulator in debug mode (press Ctrl+C to stop)...\n\n");
+        put_warning("No PPU/APU yet; this will only execute CPU instructions.\n\n");
+    }
+    else {
+        put_emulator("Running emulator (press Ctrl+C to stop)...\n\n");
+        put_warning("No PPU/APU yet; this will only execute CPU instructions.\n\n");
+    }
 
     for (int i = 0; i < GB_RUN_MAX_ITERATIONS && gb->running && !gb->cpu.halted; i++) {
         gb_step(gb);
 
         if (debug_mode && (i % GB_RUN_DEBUG_INTERVAL == 0)) {
-            printf("[RUN %06d] PC=0x%04X SP=0x%04X AF=%04X BC=%04X DE=%04X HL=%04X\n", i,
-                   gb->cpu.pc, gb->cpu.sp, cpu_read_af(&gb->cpu), cpu_read_bc(&gb->cpu),
-                   cpu_read_de(&gb->cpu), cpu_read_hl(&gb->cpu));
+            put_debug("[RUN %06d] PC=0x%04X SP=0x%04X AF=%04X BC=%04X DE=%04X HL=%04X\n", i,
+                      gb->cpu.pc, gb->cpu.sp, cpu_read_af(&gb->cpu), cpu_read_bc(&gb->cpu),
+                      cpu_read_de(&gb->cpu), cpu_read_hl(&gb->cpu));
         }
     }
 
-    printf("\nEmulation finished.\n");
+    puts("");
+    put_info("Emulation finished!\n");
     gb_print_state(gb);
 
+    // BUG: if GB_RUN_MAX_ITERATIONS is reached, we still reutrn GB_RUN_OK
+    // This behavior needs to be changed
     return gb->cpu.halted ? GB_RUN_HALTED : GB_RUN_OK;
 }
 
 // Execute until HALT / cycle budget reached / PC gets stuck (used by `-t`)
 GbRunStatus gb_run_test(GameBoy *gb, bool debug_mode) {
-    printf("Running test ROM...\n");
-    printf("(Serial output will appear below)\n");
-    printf("────────────────────────────────────────────────────────────────\n\n");
+    if (debug_mode) {
+        put_emulator("Running test ROM in debug mode...\n");
+        put_info("Serial output will appear below.\n\n");
+    }
+    else {
+        put_emulator("Running test ROM...\n");
+        put_info("Serial output will appear below.\n\n");
+    }
+    put_bold("────────────────────────────────────────────────────────────────\n\n");
 
     u64         last_pc        = 0;
     u64         pc_stuck_count = 0;
@@ -189,19 +212,20 @@ GbRunStatus gb_run_test(GameBoy *gb, bool debug_mode) {
 
         // Debug: Print full trace for the first GB_TEST_TRACE_CYCLES cycles
         if (gb->cycles < GB_TEST_TRACE_CYCLES) {
-            printf("[%llu] PC=0x%04X opcode=0x%02X A=%02X F=%02X BC=%04X DE=%04X HL=%04X "
-                   "SP=%04X\n",
-                   (unsigned long long)gb->cycles, pc_before, mmu_read(gb, pc_before),
-                   gb->cpu.regs.a, gb->cpu.regs.f, cpu_read_bc(&gb->cpu), cpu_read_de(&gb->cpu),
-                   cpu_read_hl(&gb->cpu), gb->cpu.sp);
+            put_debug("[%llu] PC=0x%04X opcode=0x%02X A=%02X F=%02X BC=%04X DE=%04X HL=%04X "
+                      "SP=%04X\n",
+                      (unsigned long long)gb->cycles, pc_before, mmu_read(gb, pc_before),
+                      gb->cpu.regs.a, gb->cpu.regs.f, cpu_read_bc(&gb->cpu), cpu_read_de(&gb->cpu),
+                      cpu_read_hl(&gb->cpu), gb->cpu.sp);
         }
 
         // Detect infinite loops
         if (pc_before == last_pc) {
             pc_stuck_count++;
             if (pc_stuck_count > GB_TEST_STUCK_LIMIT) {
-                printf("\n[ERROR] CPU stuck in infinite loop at PC=0x%04X\n", pc_before);
-                printf("Opcode at PC: 0x%02X\n", mmu_read(gb, pc_before));
+                puts("");
+                put_error("CPU stuck in infinite loop at PC=0x%04X\n", pc_before);
+                put_error("Opcode at PC: 0x%02X\n", mmu_read(gb, pc_before));
                 status = GB_RUN_STUCK;
                 break;
             }
@@ -212,22 +236,23 @@ GbRunStatus gb_run_test(GameBoy *gb, bool debug_mode) {
         }
 
         if (debug_mode && (gb->cycles % GB_TEST_DEBUG_INTERVAL == 0)) {
-            printf("[%llu cycles] PC=0x%04X\n", (unsigned long long)gb->cycles, gb->cpu.pc);
+            put_debug("[%llu cycles] PC=0x%04X\n", (unsigned long long)gb->cycles, gb->cpu.pc);
         }
     }
 
-    printf("────────────────────────────────────────────────────────────────\n\n");
+    puts("");
+    put_bold("────────────────────────────────────────────────────────────────\n\n");
 
     if (status == GB_RUN_STUCK) {
         // Already reported above
     }
     else if (gb->cpu.halted) {
-        printf("Test completed (CPU halted)\n");
+        put_success("Test completed (CPU halted)\n");
         status = GB_RUN_HALTED;
     }
     else if (gb->cycles >= GB_TEST_MAX_CYCLES) {
-        printf("Test timeout (exceeded %llu cycles)\n", (unsigned long long)GB_TEST_MAX_CYCLES);
-        printf("Final PC: 0x%04X\n", gb->cpu.pc);
+        put_error("Test timeout (exceeded %llu cycles)\n", (unsigned long long)GB_TEST_MAX_CYCLES);
+        put_error("Final PC: 0x%04X\n\n", gb->cpu.pc);
         status = GB_RUN_TIMEOUT;
     }
 

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -1,5 +1,7 @@
 // src/core/utils.c
 #include <core/utils.h>
+#include <stdio.h>
+#include <stdarg.h>
 
 // Swap endianness
 u16 swap_bytes(u16 val) {
@@ -85,4 +87,61 @@ u8 adjust_bcd(u8 value, bool subtract, bool carry, bool half_carry) {
 // Extend 8-bit signed to 16-bit
 i16 sign_extend_i8(u8 val) {
     return (val & 0x80) ? (i16)(val | 0xFF00) : (i16)val;
+}
+
+// ---------------------------------------------
+// Logger functions
+// ---------------------------------------------
+static void log_message(FILE *stream, const char *color, const char *prefix, const char *format,
+                        va_list args) {
+    fprintf(stream, "%s%s[%s]: ", RESET, color, prefix);
+    vfprintf(stream, format, args);
+    fprintf(stream, "%s", RESET);
+}
+
+void put_error(const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    log_message(stderr, RED, "ERROR", format, args);
+    va_end(args);
+}
+
+void put_warning(const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    log_message(stderr, YELLOW, "WARN", format, args);
+    va_end(args);
+}
+
+void put_success(const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    log_message(stdout, GREEN, "OK", format, args);
+    va_end(args);
+}
+
+void put_info(const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    log_message(stdout, CYAN, "INFO", format, args);
+    va_end(args);
+}
+
+void put_debug(const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    log_message(stdout, BLUE, "DEBUG", format, args);
+    va_end(args);
+}
+
+void put_emulator(const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    log_message(stdout, MAGENTA, "EMU", format, args);
+    va_end(args);
+}
+
+void put_bold(const char *msg) {
+    printf("%s%s%s", RESET, BOLD_WHITE, msg);
+    printf("%s", RESET);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -35,6 +35,7 @@ static void print_usage(const char *program_name) {
 }
 
 // Helper function to parse command line arguments into CliConfig
+// NOTE: Might have to migrate to cargs library in near future
 static bool parse_cli_args(int argc, char *argv[], CliConfig *config) {
     // Initialize defaults
     config->rom_path   = NULL;
@@ -43,8 +44,7 @@ static bool parse_cli_args(int argc, char *argv[], CliConfig *config) {
     config->debug_mode = false;
 
     if (argc < 2) {
-        fprintf(stderr, "Error: No ROM file specified\n\n");
-        print_usage(argv[0]);
+        put_error("No ROM file specified\n\n");
         return false;
     }
     bool mode_specified = false;
@@ -64,7 +64,7 @@ static bool parse_cli_args(int argc, char *argv[], CliConfig *config) {
             // Run mode
             else if (strcmp(argv[i], "-r") == 0) {
                 if (config->step_count > 0) {
-                    fprintf(stderr, "Error: -r and -s cannot be used together\n");
+                    put_error("-r and -s cannot be used together\n\n");
                     return false;
                 }
                 config->mode   = MODE_RUN;
@@ -74,20 +74,20 @@ static bool parse_cli_args(int argc, char *argv[], CliConfig *config) {
             // Step mode
             else if (strcmp(argv[i], "-s") == 0) {
                 if (config->mode == MODE_RUN) {
-                    fprintf(stderr, "Error: -s and -r cannot be used together\n");
+                    put_error("-s and -r cannot be used together\n\n");
                     return false;
                 }
                 if (config->mode == MODE_TEST) {
-                    fprintf(stderr, "Error: -s and -t cannot be used together\n");
+                    put_error("-s and -t cannot be used together\n\n");
                     return false;
                 }
                 if (i + 1 >= argc) {
-                    fprintf(stderr, "Error: -s requires a number\n");
+                    put_error("-s requires a number\n\n");
                     return false;
                 }
                 config->step_count = atoi(argv[++i]);
                 if (config->step_count <= 0) {
-                    fprintf(stderr, "Error: Invalid step count\n");
+                    put_error("Invalid step count\n\n");
                     return false;
                 }
                 config->mode   = MODE_STEP;
@@ -108,7 +108,7 @@ static bool parse_cli_args(int argc, char *argv[], CliConfig *config) {
             // Test mode
             else if (strcmp(argv[i], "-t") == 0) {
                 if (config->step_count > 0 || config->mode == MODE_RUN) {
-                    fprintf(stderr, "Error: -t cannot be used with -s or -r\n");
+                    put_error("-t cannot be used with -s or -r\n\n");
                     return false;
                 }
                 config->mode   = MODE_TEST;
@@ -116,8 +116,7 @@ static bool parse_cli_args(int argc, char *argv[], CliConfig *config) {
             }
 
             else {
-                fprintf(stderr, "Unknown option: %s\n", argv[i]);
-                print_usage(argv[0]);
+                put_error("Unknown option: %s\n\n", argv[i]);
                 return false;
             }
         }
@@ -125,7 +124,7 @@ static bool parse_cli_args(int argc, char *argv[], CliConfig *config) {
         // Not a flag (ROM file)
         else {
             if (config->rom_path != NULL) {
-                fprintf(stderr, "Error: Multiple ROM files specified\n");
+                put_error("Multiple ROM file specified\n\n");
                 return false;
             }
             config->rom_path = argv[i];
@@ -134,20 +133,19 @@ static bool parse_cli_args(int argc, char *argv[], CliConfig *config) {
 
     // Check if the ROM file was provided
     if (!config->rom_path) {
-        fprintf(stderr, "Error: No ROM file specified\n\n");
-        print_usage(argv[0]);
+        put_error("Error: No ROM file specified\n\n");
         return false;
     }
 
     // Default to info mode if no mode specified
     if (!mode_specified) {
         config->mode = MODE_INFO;
-        printf("No mode specified; defaulting to info mode (-i)\n\n");
+        put_info("No mode specified; defaulting to info mode (-i)\n\n");
     }
 
     // Warn if info & debug mode both used
     if (config->mode == MODE_INFO && config->debug_mode) {
-        printf("Note: debug mode (-d) has no effect in info mode\n\n");
+        put_warning("debug mode (-d) has no effect in info mode\n\n");
     }
 
     return true;
@@ -207,14 +205,15 @@ static int status_to_exit_code(GbRunStatus status) {
 
 int main(int argc, char *argv[]) {
     // Print banner
-    printf("=================================\n");
-    printf("          BareDMG\n");
-    printf("    Game Boy Emulator (DMG-01)\n");
-    printf("=================================\n\n");
+    put_bold("─────────────────────────────────\n");
+    put_bold("          BareDMG\n");
+    put_bold("    Game Boy Emulator (DMG-01)\n");
+    put_bold("─────────────────────────────────\n\n");
 
     // Parse CLI args
     CliConfig config;
     if (!parse_cli_args(argc, argv, &config)) {
+        print_usage(argv[0]);
         return 1;
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -21,17 +21,21 @@ typedef struct {
 
 // Print the usage information
 static void print_usage(const char *program_name) {
-    printf("Usage: %s [options] <path_to_rom>\n", program_name);
-    printf("\n");
-    printf("Modes (mutually exclusive):\n");
-    printf("  -i               Info mode (default): load ROM, print header info, then exit\n");
-    printf("  -s <num>         Step mode: execute exactly <num> CPU instructions\n");
-    printf("  -r               Run mode: execute instructions until timeout or HALT\n");
-    printf("\n");
-    printf("Other options:\n");
-    printf("  -d               Debug mode (verbose CPU state output)\n");
-    printf("  -t               Test mode: run ROM until completion (for test ROMs)\n");
-    printf("  -h               Show this help message\n");
+    printf("%sUsage:%s %s [options] <path_to_rom>\n", BOLD_WHITE, RESET, program_name);
+
+    printf("\n%sModes (mutually exclusive):%s\n", BOLD_WHITE, RESET);
+    printf("  %s-i%s               Info mode (default): load ROM, print header info, then exit\n",
+           CYAN, RESET);
+    printf("  %s-s <num>%s         Step mode: execute exactly <num> CPU instructions\n", CYAN,
+           RESET);
+    printf("  %s-r%s               Run mode: execute instructions until timeout or HALT\n", CYAN,
+           RESET);
+
+    printf("\n%sOther options:%s\n", BOLD_WHITE, RESET);
+    printf("  %s-d%s               Debug mode (verbose CPU state output)\n", CYAN, RESET);
+    printf("  %s-t%s               Test mode: run ROM until completion (for test ROMs)\n", CYAN,
+           RESET);
+    printf("  %s-h%s               Show this help message\n", CYAN, RESET);
 }
 
 // Helper function to parse command line arguments into CliConfig
@@ -222,10 +226,13 @@ int main(int argc, char *argv[]) {
     gb_init(&gb);
     gb_load_rom(&gb, config.rom_path);
 
-    if (!gb.running) {
-        fprintf(stderr, "Failed to load ROM\n");
-        return 1;
-    }
+    // TODO: Make gb_load_rom return a bool
+    // check if either gb.running or returned value is false
+    // if it is, failed to load ROM
+    /* if (!gb.running) { */
+    /*     fprintf(stderr, "Failed to load ROM\n"); */
+    /*     return 1; */
+    /* } */
 
     // Dispatch to the driver for the selected mode
     // Each gb_run_* function owns its own loop, diagnostics, and halt/stuck/timeout detection
@@ -236,6 +243,7 @@ int main(int argc, char *argv[]) {
         case MODE_INFO:
             // Nothing to do
             // gb_load_rom already prints the header
+            // TODO: Make a gb_print_cart_info() which calls cart_print_header(&gb->cart.header);
             break;
 
         case MODE_STEP:
@@ -251,8 +259,9 @@ int main(int argc, char *argv[]) {
             break;
     }
 
+    put_emulator("Unloading cartridge...\n");
     cart_unload(&gb.cart);
-    puts("\nExiting...\n");
+    put_emulator("Exiting...\n");
 
     return status_to_exit_code(status);
 }


### PR DESCRIPTION
### Description
This PR adds proper, colorised logging across the emulator using the logger helper functions defiend in `utils.c`

```c
#define RED "\033[91m"          // Errors
#define YELLOW "\033[93m"       // Warnings
#define GREEN "\033[92m"        // Success
#define CYAN "\033[96m"         // Information
#define BLUE "\033[94m"         // Debug
#define MAGENTA "\033[95m"      // Emulator-specific
#define BOLD_WHITE "\033[1;97m" // Bold white
#define RESET "\033[0m"

void put_error(const char *format, ...);
void put_warning(const char *format, ...);
void put_success(const char *format, ...);
void put_info(const char *format, ...);
void put_debug(const char *format, ...);
void put_emulator(const char *format, ...);
void put_bold(const char *msg);

static void log_message(FILE *stream,
                        const char *color,
                        const char *prefix,
                        const char *format,
                        va_list args
);
```
Main goal was to replace the scattered manual error logging to `stderr` with a proper helper function. That ended up growing into a more complete logging system.

Logging is also being used for things like:
- Initializing I/O registers
- Parsing cartridge header
- Allocating cartridge RAM
- etc

### Related Issue
N/A

### Type of Change
<!-- Check all that apply -->
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Tests added/updated
- [ ] Documentation update

### Key changes
- Added ANSI color macros for different log types.
- Added variadic logger helpers:
  - `put_error()`
  - `put_warning()`
  - `put_success()`
  - `put_debug()`
  - `put_emulator()`
  - `put_bold()`
- Added a shared static `log_message()` helper to handle the actual formatting and output.
- Implemented proper and styled logging in `main()`, `cartridge.c`, etc

### How to Test the Changes

<img width="1435" height="799" alt="styled help menu" src="https://github.com/user-attachments/assets/0e03849e-3f4e-47d3-9c87-8b7c0f9e6541" />

1. Pull the changes.
2. Build the emulator normally.
3. Run the emulator with options in the help menu (the help menu itself has been styled : D )

---
### Additional Notes for Maintainers (optional)
There were something I noticed and have left TODO comments:

- Move cartridge header printing out of `gb_load_rom()` into a dedicated `gb_print_cart_info()` function in `gbemu.c`
- Some purely helper functions are not marked as `static`, do so to limit their linkage.
- There might also be an issue in `gb_run_continuous()` related to its returned `status_code`
