### PR TITLE
[FEATURE] Improve serial output handling and presentation

### DIFF
--- a/include/core/utils.h
+++ b/include/core/utils.h
@@ -28,6 +28,7 @@ typedef int64_t  i64;
 #define BLUE "\033[94m"         // Debug
 #define MAGENTA "\033[95m"      // Emulator-specific
 #define BOLD_WHITE "\033[1;97m" // Bold white
+#define ORANGE "\033[38;5;208m" // Serial
 #define RESET "\033[0m"
 
 // ---------------------------------------------
@@ -39,6 +40,7 @@ void put_success(const char *format, ...);
 void put_info(const char *format, ...);
 void put_debug(const char *format, ...);
 void put_emulator(const char *format, ...);
+void put_serial(const char *format, ...);
 void put_bold(const char *msg);
 
 // ---------------------------------------------

--- a/include/gbemu.h
+++ b/include/gbemu.h
@@ -125,6 +125,12 @@ void        gb_print_state(GameBoy *gb);
 void        gb_print_cart_info(GameBoy *gb);
 
 // ---------------------------------------------
+// Serial output
+// ---------------------------------------------
+void        gb_serial_receive(u8 byte);
+void        gb_serial_flush(void);
+
+// ---------------------------------------------
 // I/O Handlers (called by MMU)
 // ---------------------------------------------
 u8          io_read(GameBoy *gb, u16 addr);

--- a/src/core/bus.c
+++ b/src/core/bus.c
@@ -296,13 +296,11 @@ void io_write(GameBoy *gb, u16 addr, u8 value) {
         case 0xFF01:
             gb->io.sb = value;
             break;
+
         case 0xFF02:
             gb->io.sc = value;
-            if (CHECK_BIT(value, 7)) {
-                printf("[SERIAL] Starting transfer, SB=0x%02X ('%c')\n", gb->io.sb,
-                       gb->io.sb >= 0x20 && gb->io.sb < 0x7F ? gb->io.sb : '?');
+            if (CHECK_BIT(value, 7))
                 gb->serial_cycles = 4096;
-            }
             break;
 
         // Timer

--- a/src/core/gbemu.c
+++ b/src/core/gbemu.c
@@ -3,6 +3,48 @@
 #include <core/bus.h>
 #include <string.h>
 #include <stdio.h>
+#include <ctype.h>
+
+// ---------------------------------------------
+// Serial Output
+// Buffers transmitted serial bytes into whole lines.
+// ---------------------------------------------
+#define SERIAL_LINE_BUF_SIZE 256
+static char   serial_line_buf[SERIAL_LINE_BUF_SIZE];
+static size_t serial_line_len = 0;
+
+static void   gb_serial_flush_line(void) {
+    if (serial_line_len == 0)
+        return;
+    serial_line_buf[serial_line_len] = '\0';
+    put_serial("%s\n", serial_line_buf);
+    serial_line_len = 0;
+}
+
+// Called from gb_step() once per completed serial byte transfer
+void gb_serial_receive(u8 byte) {
+    if (byte == '\n') {
+        gb_serial_flush_line();
+        return;
+    }
+
+    // Swallow bare CR (GB test ROMs pair it with \n)
+    if (byte == '\r')
+        return;
+
+    // Prevent overflow
+    if (serial_line_len + 1 >= SERIAL_LINE_BUF_SIZE)
+        gb_serial_flush_line();
+
+    serial_line_buf[serial_line_len++] = isprint((unsigned char)byte) ? (char)byte : '.';
+}
+
+// Flush any partial-buffered line
+// NOTE: Call this once at the end of a run
+// so trailing output without a final \n doesn't get silently dropped.
+void gb_serial_flush(void) {
+    gb_serial_flush_line();
+}
 
 // Initialize the GameBoy instance
 void gb_init(GameBoy *gb) {

--- a/src/core/gbemu.c
+++ b/src/core/gbemu.c
@@ -113,14 +113,16 @@ void gb_step(GameBoy *gb) {
         if (gb->serial_cycles <= cycles) {
             // Transfer complete
             gb->serial_cycles = 0;
-            printf("[SERIAL] Outputting: '%c' (0x%02X)\n",
-                   gb->io.sb >= 0x20 && gb->io.sb < 0x7F ? gb->io.sb : '?', gb->io.sb);
-            putchar(gb->io.sb);
-            fflush(stdout);
+
+            // Output the transferred byte
+            gb_serial_receive(gb->io.sb);
+
+            // Clear transfer flag and request serial interrutp
             gb->io.sc     = CLEAR_BIT(gb->io.sc, 7);
             gb->io.if_reg = SET_BIT(gb->io.if_reg, 3);
         }
         else {
+            // Waiting for transfer to finish
             gb->serial_cycles -= cycles;
         }
     }
@@ -200,6 +202,8 @@ GbRunStatus gb_run_step(GameBoy *gb, int step_count, bool debug_mode) {
         }
     }
 
+    gb_serial_flush();
+
     gb_print_state(gb);
     return status;
 }
@@ -226,6 +230,8 @@ GbRunStatus gb_run_continuous(GameBoy *gb, bool debug_mode) {
                       cpu_read_de(&gb->cpu), cpu_read_hl(&gb->cpu));
         }
     }
+
+    gb_serial_flush();
 
     if (gb->cpu.halted) {
         status = GB_RUN_HALTED;
@@ -292,6 +298,8 @@ GbRunStatus gb_run_test(GameBoy *gb, bool debug_mode) {
             put_debug("[%llu cycles] PC=0x%04X\n", (unsigned long long)gb->cycles, gb->cpu.pc);
         }
     }
+
+    gb_serial_flush();
 
     puts("");
     put_bold("────────────────────────────────────────────────────────────────\n\n");

--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -141,6 +141,13 @@ void put_emulator(const char *format, ...) {
     va_end(args);
 }
 
+void put_serial(const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    log_message(stdout, ORANGE, "SERIAL", format, args);
+    va_end(args);
+}
+
 void put_bold(const char *msg) {
     printf("%s%s%s", RESET, BOLD_WHITE, msg);
     printf("%s", RESET);


### PR DESCRIPTION
### Description
Previously, serial output handling was spread across `gb_step()` and `io_write()`, with both functions directly printing serial-related message to `stdout`.

`gb_step()` printed every transmitted serial byte using a `printf()` statement that accessed the contents of `SB`:

```c
printf("[SERIAL] Outputting: '%c' (0x%02X)\n",
       gb->io.sb >= 0x20 && gb->io.sb < 0x7F ? gb->io.sb : '?',
       gb->io.sb);

```

Similarly, `io_write()` printed a diagnostic message whenever a transfer was started.

**This resulted in noisy and difficult-to-read serial output.**

This PR implements a new serial output handling suite which buffers the serial output in whole lines:

```c
#define SERIAL_LINE_BUF_SIZE 256
static char serial_line_buf[SERIAL_LINE_BUF_SIZE];

static void gb_serial_flush_line(void);

void gb_serial_receive(u8 byte);
void gb_serial_flush(void);
```

### Related Issue
N/A

### Type of Change
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Tests added/updated
- [ ] Documentation update

### Key changes
- Add a helper/logger function `put_serial()`.
- Updated `gb_step()` to use `gb_serial_receive()` when a serial transfer completes.
- Added `gb_serial_flush()` calls to:
  - `gb_run_step()`
  - `gb_run_continuous()`
  - `gb_run_test()`
- Removed the serial transfer debug `printf()` from `io_write()` in `bus.c`.

### How to Test the Changes

<img width="774" height="305" alt="image" src="https://github.com/user-attachments/assets/6a864201-7e2a-4c6a-95a7-4eef7ddfb1d0" />

1. Pull the changes.
2. Build BareDMG.
3. Run a Blargg CPU instruction test ROM, for example: `04-op\ r,imm.gb`
4. Verify that the serial output is now grouped into complete lines and styled properly

---
### Additional Notes for Maintainers (optional)
For some reason, the test `04-op\ r,imm.gb` still fails, as shown by the ROM's `Failed` serial output.

This is unrelated to the serial-output refactor. The underlying CPU/test failure needs to be investigated separately in an another issue.